### PR TITLE
feat: add edge response and build edges functionality for trip steps

### DIFF
--- a/catalyst-api.code-workspace
+++ b/catalyst-api.code-workspace
@@ -21,7 +21,8 @@
     "cSpell.words": [
       "bsodium",
       "esbenp",
-      "heroui"
+      "heroui",
+      "Polarsteps"
     ],
     "chat.tools.terminal.autoApprove": {
       "cd": true,

--- a/src/app/polarsteps/Types.d.ts
+++ b/src/app/polarsteps/Types.d.ts
@@ -106,10 +106,21 @@ export interface StepResponse {
 }
 
 /**
+ * An edge connecting two consecutive steps within a trip
+ */
+export interface EdgeResponse {
+  from: { stepId: number; lat: number; lon: number };
+  to: { stepId: number; lat: number; lon: number };
+  type: "flight" | "ground";
+  distanceKm: number;
+}
+
+/**
  * Full trip detail for the public API response
  */
 export interface TripDetailResponse extends TripSummaryResponse {
   steps: StepResponse[];
+  edges: EdgeResponse[];
   likes?: number;
   views?: number;
 }

--- a/src/app/polarsteps/[tripId]/route.ts
+++ b/src/app/polarsteps/[tripId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getTrip } from "../client";
+import { buildEdges } from "../geo";
 import { StepResponse, TripDetailResponse } from "../Types";
 
 export const revalidate = 86400; // 24 hours ISR
@@ -61,6 +62,7 @@ export async function GET(
         trip.cover_photo?.large_thumbnail_path ?? trip.cover_photo?.path,
       countryCodes: trip.country_codes,
       steps,
+      edges: buildEdges(allSteps),
       likes: trip.likes,
       views: trip.views,
     };

--- a/src/app/polarsteps/geo.ts
+++ b/src/app/polarsteps/geo.ts
@@ -56,7 +56,15 @@ export function buildEdges(steps: PolarstepsStep[]): EdgeResponse[] {
         location: NonNullable<PolarstepsStep["location"]>;
       } => s.location != null,
     )
-    .sort((a, b) => (a.start_time ?? 0) - (b.start_time ?? 0));
+    .sort((a, b) => {
+      const timeA = a.start_time ?? Number.POSITIVE_INFINITY;
+      const timeB = b.start_time ?? Number.POSITIVE_INFINITY;
+      if (timeA === timeB) {
+        // Fallback to stable secondary sort by ID
+        return a.id > b.id ? 1 : a.id < b.id ? -1 : 0;
+      }
+      return timeA - timeB;
+    });
 
   const edges: EdgeResponse[] = [];
 

--- a/src/app/polarsteps/geo.ts
+++ b/src/app/polarsteps/geo.ts
@@ -1,5 +1,4 @@
-import type { EdgeResponse } from "./Types";
-import { PolarstepsStep } from "./Types";
+import type { EdgeResponse, PolarstepsStep } from "./Types";
 
 const EARTH_RADIUS_KM = 6371;
 

--- a/src/app/polarsteps/geo.ts
+++ b/src/app/polarsteps/geo.ts
@@ -1,0 +1,88 @@
+import type { EdgeResponse } from "./Types";
+import { PolarstepsStep } from "./Types";
+
+const EARTH_RADIUS_KM = 6371;
+
+/** Distance between two lat/lon points in kilometers (Haversine formula). */
+export function haversineKm(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return EARTH_RADIUS_KM * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+const FLIGHT_DISTANCE_THRESHOLD_KM = 500;
+const FLIGHT_SPEED_THRESHOLD_KMH = 200;
+
+/**
+ * Heuristic: classify an edge as flight or ground travel.
+ * - Flight if great-circle distance > 500 km
+ * - Flight if speed > 200 km/h (when timestamps are available)
+ * - Ground otherwise
+ */
+export function inferTransportType(
+  distanceKm: number,
+  timeDeltaSeconds: number | null,
+): "flight" | "ground" {
+  if (distanceKm > FLIGHT_DISTANCE_THRESHOLD_KM) return "flight";
+
+  if (timeDeltaSeconds != null && timeDeltaSeconds > 0) {
+    const speedKmh = distanceKm / (timeDeltaSeconds / 3600);
+    if (speedKmh > FLIGHT_SPEED_THRESHOLD_KMH) return "flight";
+  }
+
+  return "ground";
+}
+
+/**
+ * Build edges connecting consecutive steps that have location data.
+ * Steps are sorted by start_time before computing edges.
+ */
+export function buildEdges(steps: PolarstepsStep[]): EdgeResponse[] {
+  // Filter to steps with location, then sort by start_time
+  const located = steps
+    .filter(
+      (
+        s,
+      ): s is PolarstepsStep & {
+        location: NonNullable<PolarstepsStep["location"]>;
+      } => s.location != null,
+    )
+    .sort((a, b) => (a.start_time ?? 0) - (b.start_time ?? 0));
+
+  const edges: EdgeResponse[] = [];
+
+  for (let i = 0; i < located.length - 1; i++) {
+    const from = located[i];
+    const to = located[i + 1];
+
+    const distanceKm = haversineKm(
+      from.location.lat,
+      from.location.lon,
+      to.location.lat,
+      to.location.lon,
+    );
+
+    const timeDelta =
+      from.start_time != null && to.start_time != null
+        ? to.start_time - from.start_time
+        : null;
+
+    edges.push({
+      from: { stepId: from.id, lat: from.location.lat, lon: from.location.lon },
+      to: { stepId: to.id, lat: to.location.lat, lon: to.location.lon },
+      type: inferTransportType(distanceKm, timeDelta),
+      distanceKm: Math.round(distanceKm),
+    });
+  }
+
+  return edges;
+}

--- a/src/app/polarsteps/steps/route.ts
+++ b/src/app/polarsteps/steps/route.ts
@@ -1,7 +1,8 @@
 import details from "@/app/assets/details.json";
 import { NextResponse } from "next/server";
 import { getTrip, getUserByUsername } from "../client";
-import { PolarstepsStep, StepResponse } from "../Types";
+import { buildEdges } from "../geo";
+import { EdgeResponse, PolarstepsStep, StepResponse } from "../Types";
 
 export const revalidate = 86400; // 24 hours ISR
 
@@ -56,19 +57,27 @@ export async function GET(request: Request) {
       trips.map((t) => getTrip(String(t.id))),
     );
 
-    // Collect all named steps across all trips
+    // Collect all named steps across all trips, and build edges per trip
     const allSteps: (StepResponse & { tripName: string })[] = [];
+    const allEdges: (EdgeResponse & { tripId: number; tripName: string })[] =
+      [];
     for (const trip of tripDetails) {
       const steps = trip.all_steps ?? [];
+      const tripName = trip.name?.trim() ?? "Untitled Trip";
+
+      // Build edges from ALL located steps (before name filtering) so routes stay complete
+      const edges = buildEdges(steps);
+      for (const edge of edges) {
+        allEdges.push({ ...edge, tripId: trip.id, tripName });
+      }
+
       const filtered = namedOnly
         ? steps.filter((s) => "name" in s && "description" in s)
         : steps;
 
       for (const step of filtered) {
         if (!step.location) continue; // skip steps without a location
-        allSteps.push(
-          transformStep(step, trip.name?.trim() ?? "Untitled Trip"),
-        );
+        allSteps.push(transformStep(step, tripName));
       }
     }
 
@@ -82,7 +91,7 @@ export async function GET(request: Request) {
       return true;
     });
 
-    return NextResponse.json(capped);
+    return NextResponse.json({ steps: capped, edges: allEdges });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
     const status = message.includes("401") ? 401 : 500;

--- a/src/app/polarsteps/steps/route.ts
+++ b/src/app/polarsteps/steps/route.ts
@@ -57,19 +57,13 @@ export async function GET(request: Request) {
       trips.map((t) => getTrip(String(t.id))),
     );
 
-    // Collect all named steps across all trips, and build edges per trip
-    const allSteps: (StepResponse & { tripName: string })[] = [];
-    const allEdges: (EdgeResponse & { tripId: number; tripName: string })[] =
+    // Gather and filter all steps first
+    let allSteps: (PolarstepsStep & { tripId: number; tripName: string })[] =
       [];
+
     for (const trip of tripDetails) {
       const steps = trip.all_steps ?? [];
       const tripName = trip.name?.trim() ?? "Untitled Trip";
-
-      // Build edges from ALL located steps (before name filtering) so routes stay complete
-      const edges = buildEdges(steps);
-      for (const edge of edges) {
-        allEdges.push({ ...edge, tripId: trip.id, tripName });
-      }
 
       const filtered = namedOnly
         ? steps.filter((s) => "name" in s && "description" in s)
@@ -77,21 +71,48 @@ export async function GET(request: Request) {
 
       for (const step of filtered) {
         if (!step.location) continue; // skip steps without a location
-        allSteps.push(transformStep(step, tripName));
+        allSteps.push({ ...step, tripId: trip.id, tripName });
       }
     }
 
     // Cap steps per country code
     const countPerCountry = new Map<string, number>();
-    const capped = allSteps.filter((step) => {
-      const code = step.location?.countryCode ?? "unknown";
+    const cappedSteps = allSteps.filter((step) => {
+      const code = step.location?.country_code ?? "unknown";
       const count = countPerCountry.get(code) ?? 0;
       if (count >= maxPerCountry) return false;
       countPerCountry.set(code, count + 1);
       return true;
     });
 
-    return NextResponse.json({ steps: capped, edges: allEdges });
+    // Build edges from the capped step set (grouped by trip)
+    const allEdges: (EdgeResponse & { tripId: number; tripName: string })[] =
+      [];
+    const stepsByTrip = new Map<
+      number,
+      (PolarstepsStep & { tripId: number; tripName: string })[]
+    >();
+
+    for (const step of cappedSteps) {
+      const ts = stepsByTrip.get(step.tripId) ?? [];
+      ts.push(step);
+      stepsByTrip.set(step.tripId, ts);
+    }
+
+    for (const [tripId, steps] of stepsByTrip.entries()) {
+      const tripName = steps[0]?.tripName ?? "Untitled Trip";
+      const edges = buildEdges(steps);
+      for (const edge of edges) {
+        allEdges.push({ ...edge, tripId, tripName });
+      }
+    }
+
+    // Format steps for response
+    const formattedSteps = cappedSteps.map((step) =>
+      transformStep(step, step.tripName),
+    );
+
+    return NextResponse.json({ steps: formattedSteps, edges: allEdges });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
     const status = message.includes("401") ? 401 : 500;


### PR DESCRIPTION
This pull request adds logic to compute and return route edges between travel steps, including heuristics for classifying transport type (flight or ground), and integrates this data into the trip and steps API responses. The main changes include implementing geospatial calculations, updating API endpoints to return route edges, and enhancing the returned data structures.

**Geospatial logic and edge computation:**

* Added `src/app/polarsteps/geo.ts` with functions to compute distance between steps using the Haversine formula, infer transport type (flight or ground) based on distance and speed, and build edges connecting consecutive steps with location data.

**API enhancements for route data:**

* Updated `src/app/polarsteps/[tripId]/route.ts` to import and use `buildEdges`, adding an `edges` field to the trip detail response with computed route segments. ([src/app/polarsteps/[tripId]/route.tsR3](diffhunk://#diff-ca4e16d56122ab671f2d61211b1c50b38f00de4b892bb75e3d1bb531c1467a99R3), [src/app/polarsteps/[tripId]/route.tsR65](diffhunk://#diff-ca4e16d56122ab671f2d61211b1c50b38f00de4b892bb75e3d1bb531c1467a99R65))
* Updated `src/app/polarsteps/steps/route.ts` to import and use `buildEdges`, computing route edges for all trips and including them in the response as an `edges` array alongside the `steps` array. [[1]](diffhunk://#diff-b1f04478e4039e766bd7b89f553474d3456c250470c9bd6d59d126d4781c1cabL4-R5) [[2]](diffhunk://#diff-b1f04478e4039e766bd7b89f553474d3456c250470c9bd6d59d126d4781c1cabL59-R80) [[3]](diffhunk://#diff-b1f04478e4039e766bd7b89f553474d3456c250470c9bd6d59d126d4781c1cabL85-R94)

These changes enable clients to visualize or analyze the routes between steps, including basic transport type inference, in both trip and step-level API responses.